### PR TITLE
Fix the multi-class issue

### DIFF
--- a/src/clegoues/genprog4java/java/JavaSourceInfo.java
+++ b/src/clegoues/genprog4java/java/JavaSourceInfo.java
@@ -1,21 +1,20 @@
 package clegoues.genprog4java.java;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
+import clegoues.genprog4java.mut.holes.java.JavaLocation;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
-import clegoues.genprog4java.mut.holes.java.JavaLocation;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 public class JavaSourceInfo {
 
 	private static HashMap<ClassInfo, String> originalSource = new HashMap<ClassInfo, String>();
 	private static HashMap<Integer, JavaStatement> codeBank = new HashMap<Integer, JavaStatement>();
-	private static  HashMap<Integer, JavaStatement> base = new HashMap<Integer, JavaStatement>();
+	private static HashMap<Integer, JavaStatement> base = new HashMap<Integer, JavaStatement>();
 	private static HashMap<ClassInfo, CompilationUnit> baseCompilationUnits = new HashMap<ClassInfo, CompilationUnit>();
 	
-	private static HashMap<Integer, ArrayList<Integer>> lineNoToAtomIDMap = new HashMap<Integer, ArrayList<Integer>>();
+	private static HashMap<ClassInfo, HashMap<Integer, ArrayList<Integer>>> lineNoToAtomIDMap = new HashMap<>();
 	private static HashMap<Integer, ClassInfo> stmtToFile = new HashMap<Integer, ClassInfo>();
 	
 	private static HashMap<Integer,JavaLocation> locationInformation = new HashMap<Integer,JavaLocation>();
@@ -58,19 +57,24 @@ public class JavaSourceInfo {
 	}
 	
 	
-	public ArrayList<Integer> atomIDofSourceLine(int lineno) {
-		return lineNoToAtomIDMap.get(lineno);
+	public ArrayList<Integer> atomIDofSourceLine(ClassInfo cls, int lineno) {
+		return lineNoToAtomIDMap.get(cls).get(lineno);
 	}
-	public void augmentLineInfo(int stmtId, ASTNode node) {
+	public void augmentLineInfo(ClassInfo cls, int atomId, ASTNode node) {
+		HashMap<Integer, ArrayList<Integer>> clsMap = lineNoToAtomIDMap.get(cls);
+		if (clsMap == null) {
+			clsMap = new HashMap<>();
+			lineNoToAtomIDMap.put(cls, clsMap);
+		}
 		int lineNo = ASTUtils.getLineNumber(node);
 		ArrayList<Integer> lineNoList = null;
-		if (lineNoToAtomIDMap.containsKey(lineNo)) {
-			lineNoList = lineNoToAtomIDMap.get(lineNo);
+		if (clsMap.containsKey(lineNo)) {
+			lineNoList = clsMap.get(lineNo);
 		} else {
 			lineNoList = new ArrayList<Integer>();
 		}
-		lineNoList.add(stmtId);
-		lineNoToAtomIDMap.put(lineNo, lineNoList);		
+		lineNoList.add(atomId);
+		clsMap.put(lineNo, lineNoList);
 	}
 	
 	public void storeStmtInfo(JavaStatement s, ClassInfo pair) {

--- a/src/clegoues/genprog4java/localization/DefaultLocalization.java
+++ b/src/clegoues/genprog4java/localization/DefaultLocalization.java
@@ -509,7 +509,7 @@ public class DefaultLocalization extends Localization {
 				}
 			}
 			for (int line : coveredLines) {
-				ArrayList<Integer> atomIds = original.atomIDofSourceLine(line);
+				ArrayList<Integer> atomIds = original.atomIDofSourceLine(targetClassInfo, line);
 				if (atomIds != null && atomIds.size() >= 0) {
 					atoms.addAll(atomIds);
 				}
@@ -532,7 +532,7 @@ public class DefaultLocalization extends Localization {
 					className = className.contains(".")? className.split(".")[0] : className;
 					String lineNumberString = line.split(",")[2].trim();
 					int lineNumber = Integer.parseInt(lineNumberString);
-					ArrayList<Integer> atomIds = original.atomIDofSourceLine(lineNumber);
+					ArrayList<Integer> atomIds = original.atomIDofSourceLine(new ClassInfo(className, packageName), lineNumber);
 					if(atomIds!=null){
 						for(int atomId:atomIds){
 							ClassInfo ci = original.getFileFromStmt(atomId);

--- a/src/clegoues/genprog4java/mut/edits/java/ExpressionModAdd.java
+++ b/src/clegoues/genprog4java/mut/edits/java/ExpressionModAdd.java
@@ -8,9 +8,15 @@ import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
 import clegoues.genprog4java.mut.EditHole;
-import clegoues.genprog4java.mut.Mutation;
 import clegoues.genprog4java.mut.holes.java.ExpChoiceHole;
 import clegoues.genprog4java.mut.holes.java.JavaLocation;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ConditionalExpression;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import java.util.HashMap;
 
 public class ExpressionModAdd extends ExpressionReplacer {
 
@@ -38,7 +44,8 @@ public class ExpressionModAdd extends ExpressionReplacer {
 		InfixExpression newExpression = rewriter.getAST().newInfixExpression();
 		newExpression.setOperator(newOperator);
 		newExpression.setLeftOperand((Expression) rewriter.createCopyTarget(locationExp));
-		newExpression.setRightOperand((Expression) rewriter.createCopyTarget(newExpCode));
+		Expression rightOp = (Expression) ASTNode.copySubtree(rewriter.getAST(), newExpCode);
+		newExpression.setRightOperand(rightOp);
 		this.replaceExp(rewriter, newExpression);
 	}
 

--- a/src/clegoues/genprog4java/rep/JavaRepresentation.java
+++ b/src/clegoues/genprog4java/rep/JavaRepresentation.java
@@ -33,84 +33,9 @@
 
 package clegoues.genprog4java.rep;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.ObjectStreamException;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.ToolProvider;
-
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.log4j.Logger;
-import org.eclipse.jdt.core.dom.AST;
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.AssertStatement;
-import org.eclipse.jdt.core.dom.Block;
-import org.eclipse.jdt.core.dom.BreakStatement;
-import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.ConstructorInvocation;
-import org.eclipse.jdt.core.dom.ContinueStatement;
-import org.eclipse.jdt.core.dom.DoStatement;
-import org.eclipse.jdt.core.dom.EmptyStatement;
-import org.eclipse.jdt.core.dom.EnhancedForStatement;
-import org.eclipse.jdt.core.dom.ExpressionStatement;
-import org.eclipse.jdt.core.dom.ForStatement;
-import org.eclipse.jdt.core.dom.IfStatement;
-import org.eclipse.jdt.core.dom.LabeledStatement;
-import org.eclipse.jdt.core.dom.MethodRef;
-import org.eclipse.jdt.core.dom.ReturnStatement;
-import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
-import org.eclipse.jdt.core.dom.SwitchCase;
-import org.eclipse.jdt.core.dom.SwitchStatement;
-import org.eclipse.jdt.core.dom.SynchronizedStatement;
-import org.eclipse.jdt.core.dom.ThrowStatement;
-import org.eclipse.jdt.core.dom.TryStatement;
-import org.eclipse.jdt.core.dom.TypeDeclarationStatement;
-import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
-import org.eclipse.jdt.core.dom.WhileStatement;
-import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.text.edits.MalformedTreeException;
-import org.eclipse.text.edits.TextEdit;
-import org.jacoco.core.analysis.Analyzer;
-import org.jacoco.core.analysis.CoverageBuilder;
-import org.jacoco.core.analysis.IClassCoverage;
-import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.data.ExecutionData;
-import org.jacoco.core.data.ExecutionDataReader;
-import org.jacoco.core.data.ExecutionDataStore;
-import org.jacoco.core.data.IExecutionDataVisitor;
-import org.jacoco.core.data.ISessionInfoVisitor;
-import org.jacoco.core.data.SessionInfo;
-
-import clegoues.genprog4java.Search.GiveUpException;
 import clegoues.genprog4java.Search.Search;
 import clegoues.genprog4java.fitness.TestCase;
-import clegoues.genprog4java.java.ASTUtils;
-import clegoues.genprog4java.java.ClassInfo;
-import clegoues.genprog4java.java.JavaParser;
-import clegoues.genprog4java.java.JavaSemanticInfo;
-import clegoues.genprog4java.java.JavaSourceInfo;
-import clegoues.genprog4java.java.JavaStatement;
-import clegoues.genprog4java.java.ScopeInfo;
+import clegoues.genprog4java.java.*;
 import clegoues.genprog4java.localization.Localization;
 import clegoues.genprog4java.localization.Location;
 import clegoues.genprog4java.main.Configuration;
@@ -123,6 +48,23 @@ import clegoues.genprog4java.mut.edits.java.JavaEditOperation;
 import clegoues.genprog4java.mut.holes.java.JavaLocation;
 import clegoues.util.ConfigurationBuilder;
 import clegoues.util.GlobalUtils;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+import org.eclipse.jdt.core.dom.*;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.text.edits.MalformedTreeException;
+import org.eclipse.text.edits.TextEdit;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+import java.io.*;
+import java.util.*;
 
 public class JavaRepresentation extends
 CachingRepresentation<JavaEditOperation> {
@@ -163,8 +105,8 @@ CachingRepresentation<JavaEditOperation> {
 		return retVal;
 	}
 
-	public ArrayList<Integer> atomIDofSourceLine(int lineno) {
-		return sourceInfo.atomIDofSourceLine(lineno);
+	public ArrayList<Integer> atomIDofSourceLine(ClassInfo cls, int lineno) {
+		return sourceInfo.atomIDofSourceLine(cls, lineno);
 	}
 	
 	public ClassInfo getFileFromStmt(int stmtId){
@@ -196,7 +138,7 @@ CachingRepresentation<JavaEditOperation> {
 				s.setInfo(stmtCounter, node);
 				stmtCounter++;
 
-				sourceInfo.augmentLineInfo(s.getStmtId(), node);
+				sourceInfo.augmentLineInfo(pair, s.getStmtId(), node);
 				sourceInfo.storeStmtInfo(s, pair);
 				s.setRequiredNames(scopeInfo.getRequiredNames(node));
 				s.setNamesDeclared(scopeInfo.getNamesDeclared(node));

--- a/src/clegoues/genprog4java/rep/Representation.java
+++ b/src/clegoues/genprog4java/rep/Representation.java
@@ -54,11 +54,20 @@ import clegoues.genprog4java.java.ClassInfo;
 import clegoues.genprog4java.localization.Localization;
 import clegoues.genprog4java.localization.Location;
 import clegoues.genprog4java.localization.UnexpectedCoverageResultException;
-import clegoues.genprog4java.mut.EditHole;
-import clegoues.genprog4java.mut.EditOperation;
-import clegoues.genprog4java.mut.Mutation;
-import clegoues.genprog4java.mut.WeightedHole;
-import clegoues.genprog4java.mut.WeightedMutation;
+import clegoues.genprog4java.mut.*;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 // it's not clear that this EditOperation thing is a good choice because 
 // it basically forces the patch representation.  Possibly it's flexible and the naming scheme is 
@@ -183,7 +192,7 @@ Comparable<Representation<G>> {
 
 	public abstract Boolean doesEditApply(Location location, Mutation editType);
 
-	public abstract ArrayList<Integer> atomIDofSourceLine(int line);
+	public abstract ArrayList<Integer> atomIDofSourceLine(ClassInfo cls, int line);
 
 	public abstract Location instantiateLocation(Integer i, double negWeight);
 


### PR DESCRIPTION
# Problem

When multiple classes are specified in the `targetClassName` option, line numbers from different files are messed up. 

# Solution

Change the `lineNoToAtomIDMap` field in `JavaSourceInfo` to consider `ClassInfo`. [b5ba1f6](https://github.com/squaresLab/genprog4java/commit/b5ba1f612d152d3b3db0ea347091903263e60ad5) and [e3f35b1](https://github.com/squaresLab/genprog4java/commit/e3f35b18146959d7e71527815f83f139a1cb2bde) are follow-up fixes to the mutation process. 