### PR TITLE
Workarounds for null dereference bugs

### DIFF
--- a/src/clegoues/genprog4java/java/JavaStatement.java
+++ b/src/clegoues/genprog4java/java/JavaStatement.java
@@ -334,6 +334,9 @@ public class JavaStatement implements Comparable<JavaStatement>{
 		if(extendableExpressions == null) {
 			extendableExpressions = new HashMap<Expression, List<Expression>>();
 			final MethodDeclaration md = (MethodDeclaration) ASTUtils.getEnclosingMethod(this.getASTNode());
+			if (md == null) {
+				return extendableExpressions;
+			}
 			final String methodName = md.getName().getIdentifier();
 			final List<Expression> replacements = JavaSemanticInfo.getConditionalExtensionExpressions(methodName, md);
 
@@ -389,6 +392,9 @@ public class JavaStatement implements Comparable<JavaStatement>{
 			methodParamReplacements = new HashMap<Expression,List<Expression>>();
 
 			final MethodDeclaration md = (MethodDeclaration) ASTUtils.getEnclosingMethod(this.getASTNode());
+			if (md == null) {
+				return methodParamReplacements;
+			}
 			final String methodName = md.getName().getIdentifier();
 			final Set<String> namesInScopeHere = JavaSemanticInfo.inScopeAt(this);
 
@@ -492,6 +498,9 @@ public class JavaStatement implements Comparable<JavaStatement>{
 			extendableParameterMethods = new HashMap<ASTNode,List<List<ASTNode>>>();
 
 			final MethodDeclaration md = (MethodDeclaration) ASTUtils.getEnclosingMethod(this.getASTNode());
+			if (md == null) {
+				return extendableParameterMethods;
+			}
 			final String methodName = md.getName().getIdentifier();
 			final Set<String> namesInScopeHere = JavaSemanticInfo.inScopeAt(this);
 
@@ -599,6 +608,9 @@ public class JavaStatement implements Comparable<JavaStatement>{
 				public boolean visit(MethodInvocation node) {
 					Expression methodCall = node.getExpression();
 					SimpleName methodName = node.getName();
+					if(methodCall == null || methodName == null) {
+						return true;
+					}
 					switch(methodName.getIdentifier()) {
 					case "removeRange":
 					case "subList":

--- a/src/clegoues/genprog4java/mut/edits/java/MethodReplacer.java
+++ b/src/clegoues/genprog4java/mut/edits/java/MethodReplacer.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
@@ -34,7 +35,12 @@ public class MethodReplacer extends JavaEditOperation {
 		SimpleName newMethodName = rewriter.getAST().newSimpleName(replaceWith.getName());
 		newNode.setName(newMethodName);
 		
-		List<ASTNode> paramNodes = ((MethodInvocation) toReplace).arguments();
+		List<ASTNode> paramNodes;
+		if (toReplace instanceof SuperMethodInvocation) {
+			paramNodes = ((SuperMethodInvocation) toReplace).arguments();
+		} else {
+			paramNodes = ((MethodInvocation) toReplace).arguments();
+		}
 		for(ASTNode param : paramNodes) {
 			ASTNode newParam = rewriter.createCopyTarget(param);
 			newNode.arguments().add(newParam);

--- a/src/clegoues/genprog4java/mut/edits/java/ObjectInitializer.java
+++ b/src/clegoues/genprog4java/mut/edits/java/ObjectInitializer.java
@@ -65,7 +65,7 @@ public class ObjectInitializer extends JavaEditOperation {
 					SimpleName asExp = (SimpleName) arg;
 					ITypeBinding binding = asExp.resolveTypeBinding();
 
-					if(binding.isClass()) {
+					if(binding != null && binding.isClass()) {
 						SimpleName newVarName = myAST.newSimpleName(((SimpleName) arg).getIdentifier());
 						Assignment newAssignment = myAST.newAssignment();
 						newAssignment.setLeftHandSide(newVarName);

--- a/src/clegoues/genprog4java/mut/edits/java/RangeCheckOperation.java
+++ b/src/clegoues/genprog4java/mut/edits/java/RangeCheckOperation.java
@@ -83,7 +83,7 @@ public class RangeCheckOperation extends JavaEditOperation {
 			upperBoundCheck.setOperator(Operator.LESS);
 
 			SimpleName uqualifier = rewriter.getAST().newSimpleName(
-					((ArrayAccess) array).getArray().toString());
+					((ArrayAccess) array).getArray().toString().split("\\[")[0]);
 			SimpleName uname = rewriter.getAST().newSimpleName(
 					"length");
 			upperBoundCheck.setRightOperand(rewriter.getAST()


### PR DESCRIPTION
I've encountered some null dereference issues while running some longer experiments. I added some null safety checks that prevent the search from prematurely terminating due to the null exceptions that get thrown. These are not root-cause fixes, just workarounds that enabled us to run the search to completion. I hope that this can help pinpoint the underlying issues!